### PR TITLE
Fixes TerminateCommand error

### DIFF
--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -4,7 +4,7 @@ namespace Vzool\Horizon\Console;
 
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
-use Illuminate\Support\InteractsWithTime;
+use Illuminate\Queue\InteractsWithTime;
 use Vzool\Horizon\MasterSupervisor;
 use Vzool\Horizon\Contracts\MasterSupervisorRepository;
 


### PR DESCRIPTION
Fixes error :

```In TerminateCommand.php line 13:

  Trait 'Illuminate\Support\InteractsWithTime' not found```